### PR TITLE
fix: correct conditional logic for auto-merge PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,10 +10,13 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     if: |
-      github.actor == 'github-actions[bot]' &&
       (
-        startsWith(github.head_ref, 'update-license-') ||
-        github.head_ref == 'update-pre-commit-hooks'
+        github.actor == 'github-actions[bot]' && (
+          startsWith(github.head_ref, 'update-license-') ||
+          github.head_ref == 'update-pre-commit-hooks'
+        )
+      ) || (
+        github.actor == 'dependabot[bot]'
       )
     steps:
       - uses: peter-evans/enable-pull-request-automerge@v3


### PR DESCRIPTION
## Description

[Description of the changes made in this pull request]

## Related Issues

- Fixes #<issue_number>

## Checklist

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [ ] I have reviewed my own code for any potential issues
- [ ] I have requested reviews from appropriate team members

## Screenshots (if applicable)

[Attach screenshots or GIFs to demonstrate the changes visually]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI auto-merge rules to automatically merge Dependabot pull requests, keeping dependencies current with less manual effort.
  - Maintains existing safeguards for GitHub Actions bot pull requests; they continue to auto-merge only when predefined criteria are met.
  - No changes to application features or behavior.
  - Improves maintenance cadence and reduces overhead, helping deliver security and patch updates more quickly without impacting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->